### PR TITLE
FEAT: 과제 제출 방식에 따른 과제 제출 페이지 디자인 수정

### DIFF
--- a/src/component/page/class/AssignmentSubmit.jsx
+++ b/src/component/page/class/AssignmentSubmit.jsx
@@ -1,186 +1,220 @@
-import { useContext, useEffect, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
-import TopBar from '../../ui/TopBar';
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import { useContext, useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import TopBar from "../../ui/TopBar";
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import api from "../../api/api";
-import PlayingCurriculumSidebar from '../../ui/class/PlayingCurriculumSidebar';
-import { UsersContext } from '../../contexts/usersContext';
+import PlayingCurriculumSidebar from "../../ui/class/PlayingCurriculumSidebar";
+import { UsersContext } from "../../contexts/usersContext";
 import AssignmentModal from "../../ui/class/AssignmentModal";
-import AssignmentSubmitBox from '../../ui/class/AssignmentSubmitBox';
-import AssignmentShowBox from '../../ui/class/AssignmentShowBox';
+import AssignmentSubmitBox from "../../ui/class/AssignmentSubmitBox";
+import AssignmentShowBox from "../../ui/class/AssignmentShowBox";
 
 const ClassAssignmentSubmit = () => {
-    const navigate = useNavigate();
-    const { courseId, lectureId, assignmentId } = useParams();
-    const { user } = useContext(UsersContext);
+  const navigate = useNavigate();
+  const { courseId, lectureId, assignmentId } = useParams();
+  const { user } = useContext(UsersContext);
 
-    const [content, setContent] = useState('');
-    const [files, setFiles] = useState([]);
-    const [previousFiles, setPreviousFiles] = useState([]);
-    const [deletedFiles, setDeletedFiles] = useState([]);
-    
-    const [submissionId, setSubmissionId] = useState(null);
-    const [submissionStatus, setSubmissionStatus] = useState('');
+  const [content, setContent] = useState("");
+  const [files, setFiles] = useState([]);
+  const [previousFiles, setPreviousFiles] = useState([]);
+  const [deletedFiles, setDeletedFiles] = useState([]);
 
-    const [curriculumData, setCurriculumData] = useState([]);
-    const [currentLectureInfo, setCurrentLectureInfo] = useState([]);
-    const [currentAssignmentInfo, setCurrentAssignmentInfo] = useState([]);
+  const [submissionId, setSubmissionId] = useState(null);
+  const [submissionStatus, setSubmissionStatus] = useState("");
 
-    const [isSubmittedModalOpen, setIsSubmittedModalOpen] = useState(false);
-    const [isReSubmittedModalOpen, setIsReSubmittedModalOpen] = useState(false);
-    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-    const [canEdit, setCanEdit] = useState(false);
+  const [curriculumData, setCurriculumData] = useState([]);
+  const [currentLectureInfo, setCurrentLectureInfo] = useState([]);
+  const [currentAssignmentInfo, setCurrentAssignmentInfo] = useState([]);
 
-    const handleNavigationCurriculum = () => {
-        navigate(`/class/${courseId}/curriculum/${lectureId}`);
+  const [isSubmittedModalOpen, setIsSubmittedModalOpen] = useState(false);
+  const [isReSubmittedModalOpen, setIsReSubmittedModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [canEdit, setCanEdit] = useState(false);
+
+  const handleNavigationCurriculum = () => {
+    navigate(`/class/${courseId}/curriculum/${lectureId}`);
+  };
+
+  useEffect(() => {
+    const fetchSubmissionData = async () => {
+      try {
+        if (!assignmentId || !lectureId || !user || !courseId) return;
+
+        const lectureResponse = await api.get(
+          `/lectures/history/${courseId}/${user.userId}`
+        );
+        if (lectureResponse.data.success) {
+          const submission = lectureResponse.data.data.submissions.find(
+            (submission) => submission.assignmentId === parseInt(assignmentId)
+          );
+          if (submission) {
+            setSubmissionId(submission.submissionId);
+            setSubmissionStatus(submission.submissionStatus);
+            console.log(submissionStatus);
+          } else {
+            setSubmissionId(null);
+            setSubmissionStatus("NOT_SUBMITTED");
+          }
+        }
+      } catch (error) {
+        console.error("제출 정보 로딩 오류:", error);
+      }
     };
 
-    useEffect(() => {
-        const fetchSubmissionData = async () => {
-            try {
-                if (!assignmentId || !lectureId || !user || !courseId) return;
+    fetchSubmissionData();
+  }, [assignmentId, lectureId, courseId, user]);
 
-                const lectureResponse = await api.get(`/lectures/history/${courseId}/${user.userId}`);
-                if (lectureResponse.data.success) {
-                    const submission = lectureResponse.data.data.submissions.find(
-                        (submission) => submission.assignmentId === parseInt(assignmentId)
-                    );
-                    if (submission) {
-                        setSubmissionId(submission.submissionId);
-                        setSubmissionStatus(submission.submissionStatus);
-                        console.log(submissionStatus);
-                    } else {
-                        setSubmissionId(null);
-                        setSubmissionStatus("NOT_SUBMITTED");
-                    }
-                }
-            } catch (error) {
-                console.error("제출 정보 로딩 오류:", error);
-            }
-        };
+  useEffect(() => {
+    const fetchAssignmentData = async () => {
+      if (!submissionId || !assignmentId || !user) return;
 
-        fetchSubmissionData();
-    }, [assignmentId, lectureId, courseId, user]);
-
-    useEffect(() => {
-        const fetchAssignmentData = async () => {
-            if (!submissionId || !assignmentId || !user) return;
-
-            try {
-                const statusResponse = await api.get(
-                    `/assignments/${assignmentId}/submissions/${submissionId}/${user.userId}`
-                );
-
-                if (statusResponse.data.success) {
-                    const filesData = statusResponse.data.data.fileNames.map((fileName, index) => ({
-                        id: Date.now() + '_' + Math.random().toString(36).substr(2, 9),
-                        name: fileName,
-                        size: statusResponse.data.data.fileSizes[index],
-                        fileUrl: statusResponse.data.data.fileUrls[index],
-                    }));
-                    
-                    setFiles(filesData);
-                    setPreviousFiles(filesData);
-                    setContent(statusResponse.data.data.textContent);
-                }
-            } catch (error) {
-                console.error("과제 정보 로딩 오류:", error);
-            }
-        };
-
-        fetchAssignmentData();
-    }, [submissionId, assignmentId, user]);
-
-    useEffect(() => {
-        if (!currentLectureInfo?.videos || !assignmentId) return;
-
-        const foundAssignment = currentLectureInfo.assignments.find(
-            assignment => assignment.assignmentId === Number(assignmentId)
+      try {
+        const statusResponse = await api.get(
+          `/assignments/${assignmentId}/submissions/${submissionId}/${user.userId}`
         );
 
-        if (foundAssignment) {
-            setCurrentAssignmentInfo(foundAssignment);
+        if (statusResponse.data.success) {
+          const filesData = statusResponse.data.data.fileNames.map(
+            (fileName, index) => ({
+              id: Date.now() + "_" + Math.random().toString(36).substr(2, 9),
+              name: fileName,
+              size: statusResponse.data.data.fileSizes[index],
+              fileUrl: statusResponse.data.data.fileUrls[index],
+            })
+          );
+
+          setFiles(filesData);
+          setPreviousFiles(filesData);
+          setContent(statusResponse.data.data.textContent);
         }
-    }, [currentLectureInfo, assignmentId]);
+      } catch (error) {
+        console.error("과제 정보 로딩 오류:", error);
+      }
+    };
 
-    useEffect(() => {
-        if (submissionStatus === 'NOT_SUBMITTED') {
-            setCanEdit(true);
-        } else {
-            setCanEdit(false);
-        }
-    }, [assignmentId, submissionStatus]);
+    fetchAssignmentData();
+  }, [submissionId, assignmentId, user]);
 
-    return (
-        <Wrapper>
-        <TopBar />
-        <Container>
-            <LeftSide>
-                <TitleContainer>
-                    <MainTitle>
-                        {currentLectureInfo?.lectureDescription || "강의를 선택해주세요"}
-                    </MainTitle>
-                    
-                    <ClickContainer onClick={handleNavigationCurriculum}>
-                        <ArrowForwardIosIcon style={{ width: '13px', marginLeft: '15px' }}/>
-                    </ClickContainer>
-                </TitleContainer>
-                
-                <WhiteBoxComponent>
-                    <NoticeTitleContainer>
-                        <FormTitle style={{marginTop: '0px'}}>
-                            {currentAssignmentInfo?.assignmentTitle || "과제 제목"}
-                        </FormTitle>
-                    </NoticeTitleContainer>
-                    <NoticeContentContainer>
-                        {currentAssignmentInfo?.assignmentDescription || "과제 설명"}
-                    </NoticeContentContainer>
-                </WhiteBoxComponent>
+  useEffect(() => {
+    if (!currentLectureInfo?.videos || !assignmentId) return;
 
-                {(submissionStatus === 'NOT_SUBMITTED' || canEdit) ? (
-                    <AssignmentSubmitBox
-                        canEdit={canEdit}
-                        setCanEdit={setCanEdit}
-                        content={content}
-                        setContent={setContent}
-                        files={files}
-                        setFiles={setFiles}
-                        submissionId={submissionId}
-                        submissionStatus={submissionStatus}
-                        setIsSubmittedModalOpen={setIsSubmittedModalOpen}
-                        setIsReSubmittedModalOpen={setIsReSubmittedModalOpen}
-                    />
-                ) : (
-                    <AssignmentShowBox
-                        setCanEdit={setCanEdit}
-                        content={content}
-                        files={files}
-                        submissionId={submissionId}
-                        submissionStatus={submissionStatus}
-                        setIsDeleteModalOpen={setIsDeleteModalOpen}
-                    />
-                )}
-            </LeftSide>
-
-            <RightSide>
-                <PlayingCurriculumSidebar
-                    curriculumData={curriculumData} setCurriculumData={setCurriculumData}
-                    currentLectureInfo={currentLectureInfo} setCurrentLectureInfo={setCurrentLectureInfo}
-                />
-            </RightSide>
-
-            { isSubmittedModalOpen && <AssignmentModal text="과제 제출이 완료되었습니다."  onClose={() => {setIsSubmittedModalOpen(false); window.location.reload();}}/> }
-            { isReSubmittedModalOpen && <AssignmentModal text="과제 수정이 완료되었습니다."  onClose={() => {setIsReSubmittedModalOpen(false); window.location.reload();}}/> }
-            { isDeleteModalOpen && <AssignmentModal text="과제 삭제가 완료되었습니다."  onClose={() => {setIsDeleteModalOpen(false); window.location.reload();}}/> }
-        </Container>
-        </Wrapper>
+    const foundAssignment = currentLectureInfo.assignments.find(
+      (assignment) => assignment.assignmentId === Number(assignmentId)
     );
+
+    if (foundAssignment) {
+      setCurrentAssignmentInfo(foundAssignment);
+    }
+  }, [currentLectureInfo, assignmentId]);
+
+  useEffect(() => {
+    if (submissionStatus === "NOT_SUBMITTED") {
+      setCanEdit(true);
+    } else {
+      setCanEdit(false);
+    }
+  }, [assignmentId, submissionStatus]);
+
+  return (
+    <Wrapper>
+      <TopBar />
+      <Container>
+        <LeftSide>
+          <TitleContainer>
+            <MainTitle>
+              {currentLectureInfo?.lectureDescription || "강의를 선택해주세요"}
+            </MainTitle>
+
+            <ClickContainer onClick={handleNavigationCurriculum}>
+              <ArrowForwardIosIcon
+                style={{ width: "13px", marginLeft: "15px" }}
+              />
+            </ClickContainer>
+          </TitleContainer>
+
+          <WhiteBoxComponent>
+            <NoticeTitleContainer>
+              <FormTitle style={{ marginTop: "0px" }}>
+                {currentAssignmentInfo?.assignmentTitle || "과제 제목"}
+              </FormTitle>
+            </NoticeTitleContainer>
+            <NoticeContentContainer>
+              {currentAssignmentInfo?.assignmentDescription || "과제 설명"}
+            </NoticeContentContainer>
+          </WhiteBoxComponent>
+
+          {submissionStatus === "NOT_SUBMITTED" || canEdit ? (
+            <AssignmentSubmitBox
+              courseId={courseId}
+              userId={user?.userId}
+              canEdit={canEdit}
+              setCanEdit={setCanEdit}
+              content={content}
+              setContent={setContent}
+              files={files}
+              setFiles={setFiles}
+              submissionId={submissionId}
+              submissionStatus={submissionStatus}
+              setIsSubmittedModalOpen={setIsSubmittedModalOpen}
+              setIsReSubmittedModalOpen={setIsReSubmittedModalOpen}
+            />
+          ) : (
+            <AssignmentShowBox
+              setCanEdit={setCanEdit}
+              content={content}
+              files={files}
+              submissionId={submissionId}
+              submissionStatus={submissionStatus}
+              setIsDeleteModalOpen={setIsDeleteModalOpen}
+            />
+          )}
+        </LeftSide>
+
+        <RightSide>
+          <PlayingCurriculumSidebar
+            curriculumData={curriculumData}
+            setCurriculumData={setCurriculumData}
+            currentLectureInfo={currentLectureInfo}
+            setCurrentLectureInfo={setCurrentLectureInfo}
+          />
+        </RightSide>
+
+        {isSubmittedModalOpen && (
+          <AssignmentModal
+            text="과제 제출이 완료되었습니다."
+            onClose={() => {
+              setIsSubmittedModalOpen(false);
+              window.location.reload();
+            }}
+          />
+        )}
+        {isReSubmittedModalOpen && (
+          <AssignmentModal
+            text="과제 수정이 완료되었습니다."
+            onClose={() => {
+              setIsReSubmittedModalOpen(false);
+              window.location.reload();
+            }}
+          />
+        )}
+        {isDeleteModalOpen && (
+          <AssignmentModal
+            text="과제 삭제가 완료되었습니다."
+            onClose={() => {
+              setIsDeleteModalOpen(false);
+              window.location.reload();
+            }}
+          />
+        )}
+      </Container>
+    </Wrapper>
+  );
 };
 
 const Wrapper = styled.div`
-    height: 100vh;
-`
+  height: 100vh;
+`;
 
 const Container = styled.div`
     display: flex;
@@ -189,81 +223,81 @@ const Container = styled.div`
 `;
 
 const LeftSide = styled.div`
-    width: 70vw;
-    flex: 1;
-    padding: 0px 37px;
-    height: calc(92vh - 16px);
-    overflow-y: scroll;
-    &::-webkit-scrollbar {
-        display: none;
-    }
+  width: 70vw;
+  flex: 1;
+  padding: 0px 37px;
+  height: calc(92vh - 16px);
+  overflow-y: scroll;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const FormTitle = styled.div`
-    font-size: 17px;
-    font-weight: 700;
-    padding: 0px 10px;
-    margin-top: 5px;
+  font-size: 17px;
+  font-weight: 700;
+  padding: 0px 10px;
+  margin-top: 5px;
 `;
 
 const WhiteBoxComponent = styled.div`
-    border-radius: 20px;
-    background-color: #FFFFFF;
-    height: 30vh;
-    margin-bottom: 50px;
-    padding: 10px;
-`
+  border-radius: 20px;
+  background-color: #ffffff;
+  height: 30vh;
+  margin-bottom: 50px;
+  padding: 10px;
+`;
 
 const NoticeTitleContainer = styled.div`
-    border-radius: 13px;
-    background-color: #F6F7F9;
-    height: 40px;
-    display: flex;
-    align-items: center;
-    margin-bottom: 15px;
-`
+  border-radius: 13px;
+  background-color: #f6f7f9;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  margin-bottom: 15px;
+`;
 
 const NoticeContentContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    padding-left: 10px;
-`
+  display: flex;
+  flex-direction: column;
+  padding-left: 10px;
+`;
 
 const TitleContainer = styled.div`
-    margin-top: 36px;
-    margin-bottom: 26px;
-    display: flex;
-    align-items: flex-end;
+  margin-top: 36px;
+  margin-bottom: 26px;
+  display: flex;
+  align-items: flex-end;
 `;
 
 const MainTitle = styled.div`
-    font-size: 24px;
-    font-weight: 700;
-    display: flex;
-    align-items: center;
-    align-items: center;
-    margin-right: 10px;
+  font-size: 24px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  align-items: center;
+  margin-right: 10px;
 `;
 
 const ClickContainer = styled.div`
-    display: flex;
-    cursor: pointer;
-`
+  display: flex;
+  cursor: pointer;
+`;
 
 const RightSide = styled.div`
-    width: 30vw;
-    padding: 0px 15px;
-    padding-top: 36px;
-    background-color: #FFFFFF;
+  width: 30vw;
+  padding: 0px 15px;
+  padding-top: 36px;
+  background-color: #ffffff;
 `;
 
 const EditorContainer = styled.div`
-    border: 2px solid #CDCDCD;
-    border-radius: 8px;
-    overflow: hidden;
-    margin-top: 10px;
-    height: 18vh;
-    margin: 10px;
+  border: 2px solid #cdcdcd;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-top: 10px;
+  height: 18vh;
+  margin: 10px;
 `;
 
 const TextArea = styled.textarea`
@@ -286,45 +320,45 @@ const TextArea = styled.textarea`
 `;
 
 const ImageItemContainer = styled.div`
-    display: flex;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    gap: 10px;
-    margin: 10px;
-    padding-bottom: 5px;
-    background-color: #F6F7F9;
-    border-radius: 10px;
-    height: 40px;
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  gap: 10px;
+  margin: 10px;
+  padding-bottom: 5px;
+  background-color: #f6f7f9;
+  border-radius: 10px;
+  height: 40px;
 `;
 
 const ImageItem = styled.div`
-    display: flex;
-    align-items: center;
-    background-color: #F6F7F9;
-    padding: 5px;
-    justify-content: space-between;
-    border-radius: 8px;
+  display: flex;
+  align-items: center;
+  background-color: #f6f7f9;
+  padding: 5px;
+  justify-content: space-between;
+  border-radius: 8px;
 `;
 const ImageText = styled.div`
-    margin-right: 3px;
-    max-width: 100px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    cursor: pointer;
+  margin-right: 3px;
+  max-width: 100px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
 `;
 
 const SubmitButton = styled.button`
-    float: right;
-    padding: 8px 20px;
-    background-color: #FF4747;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
-    margin-right: 10px;
+  float: right;
+  padding: 8px 20px;
+  background-color: #ff4747;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  margin-right: 10px;
 `;
 
 export default ClassAssignmentSubmit;

--- a/src/component/page/class/CurriculumEdit.jsx
+++ b/src/component/page/class/CurriculumEdit.jsx
@@ -78,7 +78,7 @@ const CurriculumEdit = () => {
 
   const activeLectureRef = useRef(null);
   useEffect(() => {
-    activeLectureRef.current = activeLecture; // 최신 값을 저장
+    activeLectureRef.current = activeLecture;
   }, [activeLecture]);
 
   const fetchCurriculum = useCallback(

--- a/src/component/ui/class/AssignmentSubmitBox.jsx
+++ b/src/component/ui/class/AssignmentSubmitBox.jsx
@@ -1,263 +1,316 @@
-import { useContext, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import styled from 'styled-components';
+import { useContext, useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import styled from "styled-components";
 import api from "../../api/api";
 import DragZone from "../DragZone";
-import CloseIcon from '@mui/icons-material/Close';
-import { UsersContext } from '../../contexts/usersContext';
+import CloseIcon from "@mui/icons-material/Close";
+import { UsersContext } from "../../contexts/usersContext";
 
 const AssignmentSubmitBox = ({
-    content, 
-    setContent,
-    files, 
-    setFiles,
-    submissionId, 
-    submissionStatus, 
-    setCanEdit,  
-    setIsSubmittedModalOpen, 
-    setIsReSubmittedModalOpen}) => {
-    const { assignmentId } = useParams();
-    const { user } = useContext(UsersContext);
+  courseId,
+  userId,
+  content,
+  setContent,
+  files,
+  setFiles,
+  submissionId,
+  submissionStatus,
+  setCanEdit,
+  setIsSubmittedModalOpen,
+  setIsReSubmittedModalOpen,
+}) => {
+  const { assignmentId } = useParams();
+  const { user } = useContext(UsersContext);
 
-    const [previousFiles, setPreviousFiles] = useState([]);
-    const [deletedFiles, setDeletedFiles] = useState([]);
+  const [previousFiles, setPreviousFiles] = useState([]);
+  const [deletedFiles, setDeletedFiles] = useState([]);
+  const [submissionType, setSubmissionType] = useState(null);
 
-    useEffect(() => {
-        setCanEdit(true);
-    }, [assignmentId]);
+  useEffect(() => {
+    const fetchSubmissionType = async () => {
+      if (!assignmentId || !courseId || !userId) return;
 
-    const handleSubmit = async () => {
-        if (!user) return;
+      try {
+        const response = await api.get(
+          `/lectures/curriculum/${courseId}/${userId}`
+        );
 
-        if(!content && files.length === 0) {
-            alert("제출할 것이 없습니다.");
-            return;
-        }
+        if (response.data.success) {
+          const curriculumData = response.data.data.curriculumResponses;
 
-        if(files.length >= 4){
-            alert("파일은 3개까지만 업로드 가능합니다.");
-            return;
-        }
-
-        try {
-            let response;
-
-            const newFiles = files.filter(file => !file.fileUrl);
-            const existingFileUrls = files
-                .filter(file => file.fileUrl)
-                .map(file => file.fileUrl);
-            const deleteFileUrls = [...deletedFiles];
-    
-            const formData = new FormData();
-            formData.append("textContent", content);
-
-            if (newFiles.length > 0) {
-                newFiles.forEach((file) => {
-                    formData.append("files", file.object);
-                });
+          let foundType = null;
+          for (const lecture of curriculumData) {
+            const assignment = lecture.assignments.find(
+              (a) => a.assignmentId === parseInt(assignmentId)
+            );
+            if (assignment) {
+              foundType = assignment.submissionType;
+              break;
             }
-    
-            switch(submissionStatus) {
-                case "NOT_SUBMITTED": {
-                    response = await api.put(
-                        `/assignments/${assignmentId}/submissions/${submissionId}/${user.userId}`,
-                        formData,
-                        {
-                            headers: {
-                                'Content-Type': 'multipart/form-data'
-                            }
-                        }
-                    );
-                    break;
-                }
-                
-                case "LATE":
-                case "SUBMITTED": {
-                    if (existingFileUrls.length > 0) {
-                        existingFileUrls.forEach(url => {
-                            formData.append("existingFileUrls", url);
-                        });
-                    }
-                    
-                    if (deleteFileUrls.length > 0) {
-                        deleteFileUrls.forEach(url => {
-                            formData.append("deleteFileUrls", url);
-                        });
-                    }
-    
-                    response = await api.put(
-                        `/assignments/${assignmentId}/submissions/${submissionId}/${user.userId}`,
-                        formData,
-                        {
-                            headers: {
-                                'Content-Type': 'multipart/form-data'
-                            }
-                        }
-                    );
-                    break;
-                }
-            }
-            if (response.data.success) {
-                const statusResponse = await api.get(
-                    `/assignments/${assignmentId}/submissions/${submissionId}/${user.userId}`
-                );
-    
-                if (statusResponse.data.success) {
-                    submissionStatus === "NOT_SUBMITTED"
-                        ? setIsSubmittedModalOpen(true)
-                        : setIsReSubmittedModalOpen(true);
-                }
-            }
-        } catch (error) {
-            console.error("과제 제출 오류:", error);
+          }
+
+          if (foundType) {
+            setSubmissionType(foundType);
+          } else {
+            console.warn("해당 과제의 submissionType을 찾을 수 없습니다.");
+          }
         }
+      } catch (error) {
+        console.error("과제 유형 로딩 오류:", error);
+      }
     };
 
-    const DeleteImageHandle = (e, fileId) => {
-        e.preventDefault();
-    
-        const fileToDelete = files.find((file) => file.id === fileId);
-    
-        if (!fileToDelete) {
-            console.warn("삭제할 파일을 찾을 수 없습니다.");
-            return;
-        }
-    
-        if (fileToDelete.object?.preview) {
-            URL.revokeObjectURL(fileToDelete.object.preview);
-        }
-    
-        const updatedFiles = files.filter((file) => file.id !== fileId);
-        setFiles(updatedFiles);
-        
-        if (fileToDelete.fileUrl) {
-            setDeletedFiles((prev) => [...prev, fileToDelete.fileUrl]);
-        }
-    };
+    fetchSubmissionType();
+  }, [assignmentId, courseId, userId]);
 
-    return (
-        <Wrapper>
-            <Box>
-                <FormTitle>내용</FormTitle>
-                <EditorContainer>
-                    <TextArea
-                        placeholder="내용을 입력하세요"
-                        value={content || ''}
-                        onChange={(e) => setContent(e.target.value)}
-                        wrap:hard
-                    />
-                </EditorContainer>
-            </Box>
-            <Box style={{marginTop: '20px'}}>
-                <FormTitle>파일 업로드하기</FormTitle>
-                <DragZone setFiles={setFiles}/>
+  useEffect(() => {
+    setCanEdit(true);
+  }, [assignmentId]);
 
-                {files && files.map((file) => (
-                    <ImageItemContainer>
-                        <ImageItem 
-                            key={file.fileUrl} 
-                            title={file.fileName}
-                        >
-                            <ImageText title={file.fileName} onClick={(e) => OnClickImage(e, file.id)}>{file.name}</ImageText>
-                            <CloseIcon 
-                                onClick={(e) => {
-                                    DeleteImageHandle(e, file.id);
-                                }} 
-                                style={{width: '15px', cursor: 'pointer', marginLeft: '5px'}}
-                            />
-                        </ImageItem>
-                    </ImageItemContainer>
-                ))}
-            </Box>
+  const handleSubmit = async () => {
+    if (!user) return;
 
-            <SubmitButton onClick={handleSubmit}>제출하기</SubmitButton>
-        </Wrapper>
-    );
+    if (!content && files.length === 0) {
+      alert("제출할 것이 없습니다.");
+      return;
+    }
+
+    if (files.length >= 4) {
+      alert("파일은 3개까지만 업로드 가능합니다.");
+      return;
+    }
+
+    try {
+      let response;
+
+      const newFiles = files.filter((file) => !file.fileUrl);
+      const existingFileUrls = files
+        .filter((file) => file.fileUrl)
+        .map((file) => file.fileUrl);
+      const deleteFileUrls = [...deletedFiles];
+
+      const formData = new FormData();
+      formData.append("textContent", content);
+
+      if (newFiles.length > 0) {
+        newFiles.forEach((file) => {
+          formData.append("files", file.object);
+        });
+      }
+
+      switch (submissionStatus) {
+        case "NOT_SUBMITTED": {
+          response = await api.put(
+            `/assignments/${assignmentId}/submissions/${submissionId}/${user.userId}`,
+            formData,
+            {
+              headers: {
+                "Content-Type": "multipart/form-data",
+              },
+            }
+          );
+          break;
+        }
+
+        case "LATE":
+        case "SUBMITTED": {
+          if (existingFileUrls.length > 0) {
+            existingFileUrls.forEach((url) => {
+              formData.append("existingFileUrls", url);
+            });
+          }
+
+          if (deleteFileUrls.length > 0) {
+            deleteFileUrls.forEach((url) => {
+              formData.append("deleteFileUrls", url);
+            });
+          }
+
+          response = await api.put(
+            `/assignments/${assignmentId}/submissions/${submissionId}/${user.userId}`,
+            formData,
+            {
+              headers: {
+                "Content-Type": "multipart/form-data",
+              },
+            }
+          );
+          break;
+        }
+      }
+      if (response.data.success) {
+        const statusResponse = await api.get(
+          `/assignments/${assignmentId}/submissions/${submissionId}/${user.userId}`
+        );
+
+        if (statusResponse.data.success) {
+          submissionStatus === "NOT_SUBMITTED"
+            ? setIsSubmittedModalOpen(true)
+            : setIsReSubmittedModalOpen(true);
+        }
+      }
+    } catch (error) {
+      console.error("과제 제출 오류:", error);
+    }
+  };
+
+  const DeleteImageHandle = (e, fileId) => {
+    e.preventDefault();
+
+    const fileToDelete = files.find((file) => file.id === fileId);
+
+    if (!fileToDelete) {
+      console.warn("삭제할 파일을 찾을 수 없습니다.");
+      return;
+    }
+
+    if (fileToDelete.object?.preview) {
+      URL.revokeObjectURL(fileToDelete.object.preview);
+    }
+
+    const updatedFiles = files.filter((file) => file.id !== fileId);
+    setFiles(updatedFiles);
+
+    if (fileToDelete.fileUrl) {
+      setDeletedFiles((prev) => [...prev, fileToDelete.fileUrl]);
+    }
+  };
+
+  return (
+    <Wrapper>
+      {(submissionType === "TEXT" || submissionType === "BOTH") && (
+        <Box>
+          <FormTitle>내용</FormTitle>
+          <EditorContainer>
+            <TextArea
+              placeholder="내용을 입력하세요"
+              value={content || ""}
+              onChange={(e) => setContent(e.target.value)}
+              wrap:hard
+            />
+          </EditorContainer>
+        </Box>
+      )}
+
+      {(submissionType === "FILE" || submissionType === "BOTH") && (
+        <Box style={{ marginTop: submissionType === "BOTH" ? "20px" : "0px" }}>
+          <FormTitle>파일 업로드하기</FormTitle>
+          <DragZone setFiles={setFiles} />
+
+          {files &&
+            files.map((file) => (
+              <ImageItemContainer>
+                <ImageItem key={file.fileUrl} title={file.fileName}>
+                  <ImageText
+                    title={file.fileName}
+                    onClick={(e) => OnClickImage(e, file.id)}
+                  >
+                    {file.name}
+                  </ImageText>
+                  <CloseIcon
+                    onClick={(e) => {
+                      DeleteImageHandle(e, file.id);
+                    }}
+                    style={{
+                      width: "15px",
+                      cursor: "pointer",
+                      marginLeft: "5px",
+                    }}
+                  />
+                </ImageItem>
+              </ImageItemContainer>
+            ))}
+        </Box>
+      )}
+
+      <SubmitButton onClick={handleSubmit}>제출하기</SubmitButton>
+    </Wrapper>
+  );
 };
 
 const Box = styled.div`
-    gap: 10px;
-`
+  gap: 10px;
+`;
 
 const FormTitle = styled.div`
-    font-size: 17px;
-    font-weight: 700;
-    padding: 0px 10px;
-    margin-top: 5px;
+  font-size: 17px;
+  font-weight: 700;
+  padding: 0px 10px;
+  margin-top: 5px;
 `;
 
 const Wrapper = styled.div`
-    border-radius: 20px;
-    background-color: #FFFFFF;
-    height: 80vh;
-    margin-bottom: 60px;
-    padding: 10px;
-`
+  border-radius: 20px;
+  background-color: #ffffff;
+  height: 80vh;
+  margin-bottom: 60px;
+  padding: 10px;
+`;
 
 const EditorContainer = styled.div`
-    border: 2px solid #CDCDCD;
-    border-radius: 8px;
-    overflow: hidden;
-    margin-top: 10px;
-    height: 18vh;
-    margin: 10px;
+  border: 2px solid #cdcdcd;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-top: 10px;
+  height: 18vh;
+  margin: 10px;
 `;
 
 const TextArea = styled.textarea`
-    width: 100%;
-    height: 18vh;
-    padding: 16px;
-    border: none;
-    resize: none;
-    font-size: 13px;
+  width: 100%;
+  height: 18vh;
+  padding: 16px;
+  border: none;
+  resize: none;
+  font-size: 13px;
 
-    &::placeholder {
-        color: #9E9E9E;
-    }
+  &::placeholder {
+    color: #9e9e9e;
+  }
 
-    &:focus {
-        outline: none;
-    }
+  &:focus {
+    outline: none;
+  }
 `;
 
 const ImageItemContainer = styled.div`
-    display: flex;
-    flex-direaction: column;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    gap: 10px;
-    margin: 10px;
-    background-color: #F6F7F9;
-    border-radius: 8px;
-    height: 40px;
+  display: flex;
+  flex-direaction: column;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  gap: 10px;
+  margin: 10px;
+  background-color: #f6f7f9;
+  border-radius: 8px;
+  height: 40px;
 `;
 
 const ImageItem = styled.div`
-    display: flex;
-    align-items: center;
-    background-color: #F6F7F9;
-    padding: 5px;
-    justify-content: space-between;
-    border-radius: 8px;
-    text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+  background-color: #f6f7f9;
+  padding: 5px;
+  justify-content: space-between;
+  border-radius: 8px;
+  text-overflow: ellipsis;
 `;
 
 const ImageText = styled.div`
-    margin-right: 3px;
-    white-space: nowrap;
+  margin-right: 3px;
+  white-space: nowrap;
 `;
 
 const SubmitButton = styled.button`
-    padding: 8px 20px;
-    float: right;
-    background-color: #FF4747;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
-    margin-right: 10px;
+  padding: 8px 20px;
+  float: right;
+  background-color: #ff4747;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  margin-right: 10px;
 `;
 
 export default AssignmentSubmitBox;


### PR DESCRIPTION
# ✅ Check-List  
- [ ] merge할 브랜치 위치 확인 (develop)
- [ ] 리뷰어 지정 (필요 시)  
- [ ] 리뷰는 최대한 빠르게 진행  
- [ ] P1 단계 리뷰는 빠르게 확인 후 반영  
- [ ] Approve된 PR은 assigner가 머지, 수정 요청 시 재반영 후 push  

---

## 📌 Related Issues  
- closed: #118 

---

## 📎 작업 내용  
- 과제 제출 방식(글/파일)에 따른 과제 제출 페이지 디자인 수정
- 

---

## 📷 스크린샷  
(관련 이미지 첨부)  

---

## 💬 리뷰어 참고 사항  

제가 수정한 부분이 많지 않은데 왜 뭔가 수정사항이 많아보이는지 모르겠네요,,  아마 Prettier 때문에 저장할 때 자동으로 포맷팅된 것 같아요

제가 수정한 부분 정리하자면, 
- AssignmentSubmit 에서 AssignmentSubmitBox에 courseId랑 userId 파라미터 보내줌
- AssignmentSubmitBox 에서 CurriculumData 받아서 데이터 내에서 해당 과제에 대한 제출 방식 받고, 이에 따라 글/파일 box 띄우기 
이렇게만 진행했습니다!
