### PR TITLE
HOTFIX: 공지 작성 페이지로 넘어가지 않는 것 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,20 +20,21 @@ import FindPassword from "./component/page/users/FindPassword.jsx";
 import ChangePassword from "./component/page/users/ChangePassword.jsx";
 import ClassList from "./component/page/ClassList.jsx";
 import Create from "./component/page/class/Create.jsx";
-import Setting from "./component/page/class/Setting.jsx";
 import Participate from "./component/page/Participate.jsx";
 import Class from "./component/page/Class.jsx";
 import ClassOverview from "./component/page/class/Overview.jsx";
-import ClassSummary from "./component/page/class/Summary.jsx";
-import ClassStudents from "./component/page/class/Students.jsx";
 import ClassNotice from "./component/page/class/Notice.jsx";
 import NoticeCreate from "./component/page/class/NoticeCreate.jsx";
 import ClassCurriculum from "./component/page/class/Curriculum.jsx";
 import ClassCurriculumEdit from "./component/page/class/CurriculumEdit.jsx";
+import Admin from "./component/page/class/Admin.jsx";
+import ClassSummary from "./component/page/class/admin/Summary.jsx";
+import ClassStudents from "./component/page/class/admin/Students.jsx";
+import StudentDetail from "./component/page/class/admin/StudentDetail.jsx";
+import Setting from "./component/page/class/admin/Setting.jsx";
 import Dashboard from "./component/page/dashboard/Dashboard.jsx";
 import ClassPlaying from "./component/page/class/Playing.jsx";
 import ClassAssignmentSubmit from "./component/page/class/AssignmentSubmit.jsx";
-import StudentDetail from "./component/page/class/StudentDetail.jsx";
 import GoogleAuthCallback from "./component/page/users/GoogleAuthCallback.jsx";
 import GoogleAccountLink from "./component/page/users/GoogleAccountLink.jsx";
 
@@ -155,13 +156,12 @@ function App() {
               path="curriculum/:lectureId/edit"
               element={<ClassCurriculumEdit />}
             />
-            <Route path="admin/summary" element={<ClassSummary />} />
-            <Route path="admin/students" element={<ClassStudents />} />
-            <Route
-              path="admin/students/:studentId"
-              element={<StudentDetail />}
-            />
-            <Route path="admin/setting" element={<Setting />} />
+            <Route path="admin/" element={<Admin />}>
+              <Route path="summary" element={<ClassSummary />} />
+              <Route path="students" element={<ClassStudents />} />
+              <Route path="students/:studentId" element={<StudentDetail />} />
+              <Route path="setting" element={<Setting />} />
+            </Route>
             <Route
               path="playing/:lectureId/:videoId"
               element={<ClassPlaying />}

--- a/src/component/page/class/Admin.jsx
+++ b/src/component/page/class/Admin.jsx
@@ -1,0 +1,66 @@
+import { useState, useEffect, useContext } from "react";
+import { Outlet, useParams, useNavigate } from "react-router-dom";
+import api from "../../api/api";
+import { UsersContext } from "../../contexts/usersContext";
+import AdminTopBar from "../../ui/class/AdminTopBar";
+import { ModalOverlay, AlertModalContainer } from "../../ui/modal/ModalStyles";
+
+const Admin = () => {
+  const { courseId } = useParams();
+  const navigate = useNavigate();
+  const { user } = useContext(UsersContext);
+
+  const [courseData, setCourseData] = useState(null);
+  const [isCreator, setIsCreator] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+
+  useEffect(() => {
+    if (!courseId || !user) return;
+
+    const fetchCourseData = async () => {
+      try {
+        setLoading(true);
+        const response = await api.get(`/courses/${courseId}`);
+        if (response.data.success) {
+          setCourseData(response.data.data);
+          setIsCreator(response.data.data.user?.userId === user.userId);
+        }
+      } catch (error) {
+        console.error("강의 정보 가져오기 오류:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCourseData();
+  }, [courseId, user]);
+
+  const handleModalClose = () => {
+    setShowModal(false);
+    navigate("/class/list");
+  };
+
+  if (loading) return <div>로딩 중...</div>;
+  if (!courseData) return <div>강의 정보를 불러올 수 없습니다.</div>;
+
+  return (
+    <div>
+      <AdminTopBar />
+      <Outlet context={{ courseData, isCreator }} />
+      {showModal && (
+        <ModalOverlay>
+          <AlertModalContainer>
+            <div className="text">{modalMessage}</div>
+            <div className="close-button" onClick={handleModalClose}>
+              확인
+            </div>
+          </AlertModalContainer>
+        </ModalOverlay>
+      )}
+    </div>
+  );
+};
+
+export default Admin;

--- a/src/component/page/class/Notice.jsx
+++ b/src/component/page/class/Notice.jsx
@@ -3,7 +3,7 @@ import { useParams, useOutletContext } from "react-router-dom";
 import styled from "styled-components";
 import { ModalOverlay, ModalContent } from "../../ui/modal/ModalStyles";
 import { Section } from "../../ui/class/ClassLayout";
-import EditButton from "../../ui/class/EditButton";
+import EditNoticeButton from "../../ui/class/EditNoticeButton";
 import api from "../../api/api";
 import { UsersContext } from "../../contexts/usersContext";
 import PropTypes from "prop-types";
@@ -477,7 +477,7 @@ const ClassNotice = () => {
         </Section>
       </NoticeContainer>
       {isCreator && (
-        <EditButton
+        <EditNoticeButton
           to={`/class/${courseId}/overview/notice/create`}
           edit={true}
         />

--- a/src/component/page/class/admin/Setting.jsx
+++ b/src/component/page/class/admin/Setting.jsx
@@ -1,10 +1,9 @@
 import { useState, useEffect, useContext } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import AdminTopBar from "../../ui/class/AdminTopBar";
-import api from "../../api/api";
-import { UsersContext } from "../../contexts/usersContext";
-import EntryCodeCopyModal from "../../ui/class/EntryCodeCopyModal";
+import api from "../../../api/api";
+import { UsersContext } from "../../../contexts/usersContext";
+import EntryCodeCopyModal from "../../../ui/class/EntryCodeCopyModal";
 
 export default function Setting() {
   const navigate = useNavigate();
@@ -197,7 +196,6 @@ export default function Setting() {
         borderRadius: "8px",
       }}
     >
-      <AdminTopBar />
       <div style={{ margin: "1vh 0vh" }}>
         <div
           style={{

--- a/src/component/page/class/admin/StudentDetail.jsx
+++ b/src/component/page/class/admin/StudentDetail.jsx
@@ -1,12 +1,11 @@
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import AdminTopBar from "../../ui/class/AdminTopBar";
-import { Section } from "../../ui/class/ClassLayout";
+import { Section } from "../../../ui/class/ClassLayout";
 import styled from "styled-components";
 
-import assignmentIcon from "../../img/admin/student_assignment.svg";
-import api from "../../api/api";
-import Download from "../../img/icon/download.svg";
+import assignmentIcon from "../../../img/admin/student_assignment.svg";
+import api from "../../../api/api";
+import Download from "../../../img/icon/download.svg";
 
 const ClassStudents = () => {
   const { courseId, studentId } = useParams();
@@ -117,7 +116,6 @@ const ClassStudents = () => {
 
   return (
     <MainWrapper>
-      <AdminTopBar />
       <div>
         <TopBar>
           <Title>학생별 과제 보기</Title>

--- a/src/component/page/class/admin/Students.jsx
+++ b/src/component/page/class/admin/Students.jsx
@@ -1,9 +1,8 @@
 import { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import AdminTopBar from "../../ui/class/AdminTopBar";
-import { Section } from "../../ui/class/ClassLayout";
-import profileIcon from "../../img/icon/usericon.svg";
-import api from "../../api/api";
+import { Section } from "../../../ui/class/ClassLayout";
+import profileIcon from "../../../img/icon/usericon.svg";
+import api from "../../../api/api";
 import styled from "styled-components";
 
 const Main = styled.main`
@@ -436,7 +435,6 @@ const ClassStudents = () => {
 
   return (
     <Main>
-      <AdminTopBar />
       <HeaderWrap>
         <HeaderTitleRow>
           <HeaderTitle>전체 과제 보기</HeaderTitle>

--- a/src/component/page/class/admin/Summary.jsx
+++ b/src/component/page/class/admin/Summary.jsx
@@ -1,11 +1,10 @@
 import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
-import api from "../../api/api";
-import AdminTopBar from "../../ui/class/AdminTopBar";
+import api from "../../../api/api";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import styled from "styled-components";
-import StudentProgressTable from "../../ui/class/StudentProgressTable";
+import StudentProgressTable from "../../../ui/class/StudentProgressTable";
 import { StyledEngineProvider } from "@mui/material";
 import { style } from "@mui/system";
 
@@ -202,7 +201,6 @@ const ClassSummary = () => {
         borderRadius: "8px",
       }}
     >
-      <AdminTopBar />
       <div style={{ margin: "1vh 0vh" }}>
         <SummarySection>
           <Summary>요약</Summary>

--- a/src/component/ui/class/AdminTopBar.jsx
+++ b/src/component/ui/class/AdminTopBar.jsx
@@ -94,6 +94,7 @@ const TabLink = styled(NavLink)`
   white-space: nowrap;
 
   &.active {
+    color: var(--black-color);
     &::after {
       content: "";
       position: absolute;

--- a/src/component/ui/class/EditNoticeButton.jsx
+++ b/src/component/ui/class/EditNoticeButton.jsx
@@ -1,0 +1,35 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import EditBtn from "../../img/class/edit_btn.svg";
+import EditedBtn from "../../img/class/edited_btn.svg";
+
+const StyledButton = styled(Link)`
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 6vh;
+  cursor: pointer;
+
+  @media (max-width: 1024px) {
+    width: 4.5vh;
+  }
+  @media (max-width: 376px) {
+    width: 4vh;
+    bottom: 4.6%;
+    right: 5%;
+  }
+`;
+
+const EditNoticeButton = ({ to, edit }) => {
+  return (
+    <StyledButton to={to}>
+      <img
+        src={edit ? EditBtn : EditedBtn}
+        alt="Edit Button"
+        style={{ width: "100%" }}
+      />
+    </StyledButton>
+  );
+};
+
+export default EditNoticeButton;


### PR DESCRIPTION
# ✅ Check-List  
- [x] merge할 브랜치 위치 확인 (develop)
- [ ] 리뷰어 지정 (필요 시)  
- [ ] 리뷰는 최대한 빠르게 진행  
- [ ] P1 단계 리뷰는 빠르게 확인 후 반영  
- [ ] Approve된 PR은 assigner가 머지, 수정 요청 시 재반영 후 push  

---

## 📌 Related Issues  
- closed: #154 

---

## 📎 작업 내용  
- 공지사항 작성 페이지가 열리지 않는 에러 수정 원인은 아마 EditButton에서 lectureDate 필수로 받으면서 생긴 것 같다. 일단 EditNoticeButton.jsx 만들어서 긴급 수혈만 함

- 관리 페이지 active일 때 검은 글씨로 나타나게 수정함
- 관리 페이지에서 계속 탑바 재렌더링으로 번쩍 번쩍 거려서 page/class/admin 만들어서 안에 4개 파일 넣음 확인해주세요!

---

## 📷 스크린샷  

https://github.com/user-attachments/assets/eb4147b1-4b58-43f5-875a-cbec4b04e15b


---

## 💬 리뷰어 참고 사항  
