### PR TITLE
fix: 랜딩페이지, 로그인 페이지에서 auth/linked api 호출 안되게 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,18 @@
           j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
             'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
       })(window, document, 'script', 'dataLayer', 'GTM-PNTJ2SP5');</script>
+      <!--사용자 데이터 확인 코드-->
+      <script>
+        (function (c, s, q, u, a, r, e) {
+          c.hj = c.hj || function() { (c.hj.q = c.hj.q || []).push(arguments) };
+          c._hjSettings = { hjid: a };
+          r = s.getElementsByTagName('head')[0];
+          e = s.createElement('script');
+          e.async = true;
+          e.src = q + c._hjSettings.hjid + u;
+          r.appendChild(e);
+        })(window, document, 'https://static.hj.contentsquare.net/c/csq-', '.js', 6378998);
+      </script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/public/favicon_io/favicon.svg" />

--- a/src/component/ui/TopBar.jsx
+++ b/src/component/ui/TopBar.jsx
@@ -22,18 +22,24 @@ export default function TopBar() {
   };
 
   useEffect(() => {
-    const handleCheckExist = async () => {
-      const response = await checkExist();
+    // 현재 경로를 가져옵니다.
+    const currentPath = location.pathname;
 
-      if (response.data === "NONE") {
-        setIsGoogleLinked(false);
-      } else {
-        setIsGoogleLinked(true);
-      }
-    };
+    // LandingPage와 LoginPage가 아닌 경우에만 checkExist를 호출합니다.
+    if (currentPath !== "/" && currentPath !== "/login") {
+      const handleCheckExist = async () => {
+        const response = await checkExist();
 
-    handleCheckExist();
-  }, [isGoogleLinked]);
+        if (response.data === "NONE") {
+          setIsGoogleLinked(false);
+        } else {
+          setIsGoogleLinked(true);
+        }
+      };
+
+      handleCheckExist();
+    }
+  }, [isGoogleLinked, location.pathname]);
 
   const handleGoogleAuth = () => {
     try {


### PR DESCRIPTION
# ✅ Check-List  
- [x] merge할 브랜치 위치 확인 (develop)
- [ ] 리뷰어 지정 (필요 시)  
- [ ] 리뷰는 최대한 빠르게 진행  
- [ ] P1 단계 리뷰는 빠르게 확인 후 반영  
- [ ] Approve된 PR은 assigner가 머지, 수정 요청 시 재반영 후 push  

---

## 📌 Related Issues  
- closed: #이슈번호

---

## 📎 작업 내용  
- TopBar에서 useEffect로 계속 api를 호출하는데 랜딩페이지와 로그인페이지에서 이것을 막음
- index.html에 사용자 데이터 분석 가능한 스크립트 추가

---

## 📷 스크린샷  
(관련 이미지 첨부)  

---

## 💬 리뷰어 참고 사항  
