### PR TITLE
FEAT: 관리 페이지 내 요약 및 학생별 보기 페이지 통합

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ import ClassPlaying from "./component/page/class/Playing.jsx";
 import ClassAssignmentSubmit from "./component/page/class/AssignmentSubmit.jsx";
 import GoogleAuthCallback from "./component/page/users/GoogleAuthCallback.jsx";
 import GoogleAccountLink from "./component/page/users/GoogleAccountLink.jsx";
+import { LanguageProvider } from "./component/contexts/LanguageContext.jsx";
 
 // 페이지 이동 시 스크롤을 맨 위로 이동시키는 컴포넌트
 function ScrollToTop() {
@@ -129,51 +130,56 @@ function App() {
   return (
     <BrowserRouter>
       <UsersProvider>
-        <LogoutHandler />
-        <ScrollToTop /> {/* 필요 없으면 지우면 됨 */}
-        <Routes>
-          <Route path="/" element={<LandingPage />} />
-          <Route path="/oauth/callback" element={<GoogleAuthCallback />} />
-          <Route path="/oauth/account/link" element={<GoogleAccountLink />} />
-          <Route path="/login" element={<LogIn />} />
-          <Route path="/signup" element={<SignUp />} />
-          <Route path="/find-password" element={<FindPassword />} />
-          <Route path="/change-password" element={<ChangePassword />} />
-          <Route path="/class/list" element={<ClassList />} />
-          <Route path="/class/create" element={<Create />} />
-          <Route path="/class/participate" element={<Participate />} />
+        <LanguageProvider>
+          <LogoutHandler />
+          <ScrollToTop /> {/* 필요 없으면 지우면 됨 */}
+          <Routes>
+            <Route path="/" element={<LandingPage />} />
+            <Route path="/oauth/callback" element={<GoogleAuthCallback />} />
+            <Route path="/oauth/account/link" element={<GoogleAccountLink />} />
+            <Route path="/login" element={<LogIn />} />
+            <Route path="/signup" element={<SignUp />} />
+            <Route path="/find-password" element={<FindPassword />} />
+            <Route path="/change-password" element={<ChangePassword />} />
+            <Route path="/class/list" element={<ClassList />} />
+            <Route path="/class/create" element={<Create />} />
+            <Route path="/class/participate" element={<Participate />} />
 
-          <Route path="/class/:courseId" element={<Class />}>
-            <Route path="overview/info" element={<ClassOverview />} />
-            <Route path="overview/notice" element={<ClassNotice />} />
-            <Route path="overview/notice/create" element={<NoticeCreate />} />
-            <Route
-              path="overview/notice/edit/:noticeId"
-              element={<NoticeCreate />}
-            />
-            <Route path="curriculum/:lectureId" element={<ClassCurriculum />} />
-            <Route
-              path="curriculum/:lectureId/edit"
-              element={<ClassCurriculumEdit />}
-            />
-            <Route path="admin/" element={<Admin />}>
-              <Route path="summary" element={<ClassSummary />} />
-              <Route path="students" element={<ClassStudents />} />
-              <Route path="students/:studentId" element={<StudentDetail />} />
-              <Route path="setting" element={<Setting />} />
+            <Route path="/class/:courseId" element={<Class />}>
+              <Route path="overview/info" element={<ClassOverview />} />
+              <Route path="overview/notice" element={<ClassNotice />} />
+              <Route path="overview/notice/create" element={<NoticeCreate />} />
+              <Route
+                path="overview/notice/edit/:noticeId"
+                element={<NoticeCreate />}
+              />
+              <Route
+                path="curriculum/:lectureId"
+                element={<ClassCurriculum />}
+              />
+              <Route
+                path="curriculum/:lectureId/edit"
+                element={<ClassCurriculumEdit />}
+              />
+              <Route path="admin/" element={<Admin />}>
+                <Route path="summary" element={<ClassSummary />} />
+                <Route path="students" element={<ClassStudents />} />
+                <Route path="students/:studentId" element={<StudentDetail />} />
+                <Route path="setting" element={<Setting />} />
+              </Route>
+              <Route
+                path="playing/:lectureId/:videoId"
+                element={<ClassPlaying />}
+              />
+              <Route
+                path="assignment/submit/:lectureId/:assignmentId"
+                element={<ClassAssignmentSubmit />}
+              />
             </Route>
-            <Route
-              path="playing/:lectureId/:videoId"
-              element={<ClassPlaying />}
-            />
-            <Route
-              path="assignment/submit/:lectureId/:assignmentId"
-              element={<ClassAssignmentSubmit />}
-            />
-          </Route>
 
-          <Route path="/dashboard" element={<Dashboard />} />
-        </Routes>
+            <Route path="/dashboard" element={<Dashboard />} />
+          </Routes>
+        </LanguageProvider>
       </UsersProvider>
     </BrowserRouter>
   );

--- a/src/component/contexts/LanguageContext.jsx
+++ b/src/component/contexts/LanguageContext.jsx
@@ -1,0 +1,95 @@
+import { createContext, useContext, useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import axios from "axios";
+import { collectVisibleTexts } from "../../utils/collectVisibleTexts";
+
+const LanguageContext = createContext();
+
+export const LanguageProvider = ({ children }) => {
+  const browserLang = navigator.language.split("-")[0];
+
+  const defaultTargetLang = ["ko", "en"].includes(browserLang)
+    ? browserLang
+    : "en";
+
+  const [targetLang, setTargetLang] = useState(defaultTargetLang);
+
+  const location = useLocation();
+
+  const translateVisibleTexts = async (texts, lang = targetLang) => {
+    if (lang === browserLang) {
+      return;
+    }
+
+    if (texts.length === 0) return;
+
+    const joinedText = texts.join("\n");
+
+    try {
+      const response = await axios.post(
+        `${import.meta.env.VITE_API_URL}/translate`,
+        {
+          text: joinedText,
+          sourceLang: "auto",
+          targetLang: lang,
+        },
+      );
+
+      const translatedArray = response.data.data.split("\n");
+      const textNodes = [];
+
+      const walker = document.createTreeWalker(
+        document.body,
+        NodeFilter.SHOW_TEXT,
+        {
+          acceptNode: (node) => {
+            if (!node.parentElement) return NodeFilter.FILTER_REJECT;
+            if (node.parentElement.tagName === "SCRIPT")
+              return NodeFilter.FILTER_REJECT;
+            if (node.parentElement.tagName === "STYLE")
+              return NodeFilter.FILTER_REJECT;
+            if (!node.nodeValue.trim()) return NodeFilter.FILTER_REJECT;
+            return NodeFilter.FILTER_ACCEPT;
+          },
+        },
+      );
+
+      while (walker.nextNode()) {
+        textNodes.push(walker.currentNode);
+      }
+
+      for (let i = 0; i < textNodes.length && i < translatedArray.length; i++) {
+        textNodes[i].nodeValue = translatedArray[i];
+      }
+    } catch (error) {
+      console.error("번역 실패:", error);
+    }
+  };
+
+  // 페이지 이동할 때 자동으로 다시 번역
+  useEffect(() => {
+    const doTranslate = async () => {
+      if (targetLang === browserLang) {
+        return;
+      }
+      const visibleTexts = collectVisibleTexts();
+      await translateVisibleTexts(visibleTexts, targetLang);
+    };
+
+    doTranslate();
+  }, [location.pathname, targetLang]);
+
+  return (
+    <LanguageContext.Provider
+      value={{
+        targetLang,
+        setTargetLang,
+        translateVisibleTexts,
+      }}
+    >
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => useContext(LanguageContext);

--- a/src/component/img/landing/translate.svg
+++ b/src/component/img/landing/translate.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.5837 12C16.5837 19.3333 12.0003 23 12.0003 23C12.0003 23 7.41699 19.3333 7.41699 12C7.41699 4.66667 12.0003 1 12.0003 1C12.0003 1 16.5837 4.66667 16.5837 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1.62598 8.33325H22.3747" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1.62598 15.6667H22.3747" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/component/page/class/admin/StudentDetail.jsx
+++ b/src/component/page/class/admin/StudentDetail.jsx
@@ -121,9 +121,9 @@ const ClassStudents = () => {
           <Title>학생별 과제 보기</Title>
           <TimeText>{currentTime} 기준</TimeText>
           <NavButton
-            onClick={() => navigate(`/class/${courseId}/admin/students`)}
+            onClick={() => navigate(`/class/${courseId}/admin/summary`)}
           >
-            과제 보기
+            요약 보기
           </NavButton>
         </TopBar>
 

--- a/src/component/ui/TopBar.jsx
+++ b/src/component/ui/TopBar.jsx
@@ -7,6 +7,9 @@ import { UsersContext } from "../contexts/usersContext";
 import { UsersInfoContainer } from "../page/users/UsersInfoContainer";
 import { checkExist } from "../api/usersApi";
 import api from "../api/api";
+import { useLanguage } from "../contexts/LanguageContext";
+import { collectVisibleTexts } from "../../utils/collectVisibleTexts";
+import Translate from "../img/landing/translate.svg";
 
 export default function TopBar() {
   const navigate = useNavigate();
@@ -16,6 +19,8 @@ export default function TopBar() {
   // 드롭다운 상태 추가
   const [showUsersInfoContainer, setShowUsersInfoContainer] = useState(false);
   const [isGoogleLinked, setIsGoogleLinked] = useState(null);
+
+  const { targetLang, setTargetLang, translateVisibleTexts } = useLanguage();
 
   const handleUserIconClick = () => {
     setShowUsersInfoContainer((prev) => !prev); // 드롭다운 토글
@@ -73,6 +78,30 @@ export default function TopBar() {
           location.pathname !== "/signup" &&
           location.pathname !== "/find-password" && (
             <div className="header-right">
+              <div className="language-switcher">
+                <TranslateIcon src={Translate} />
+                <span
+                  className={
+                    targetLang === "ko" ? "lang-active" : "lang-inactive"
+                  }
+                  onClick={() => {
+                    if (targetLang !== "ko") setTargetLang("ko");
+                  }}
+                >
+                  KR
+                </span>
+                <div className="divider">|</div>
+                <span
+                  className={
+                    targetLang === "en" ? "lang-active" : "lang-inactive"
+                  }
+                  onClick={() => {
+                    if (targetLang !== "en") setTargetLang("en");
+                  }}
+                >
+                  EN
+                </span>
+              </div>
               {isUser ? (
                 <UserContainer>
                   {location.pathname === "/dashboard" ? (
@@ -217,6 +246,33 @@ const Header = styled.header`
     min-width: 50px;
     font-size: 12px;
   }
+
+  .language-switcher {
+    display: flex;
+    align-items: center;
+    gap: 1vh;
+    font-size: 17px;
+    font-weight: 500;
+    cursor: pointer;
+    margin-right: 2vh;
+  }
+
+  .langs {
+    display: flex;
+    align-items: center;
+  }
+
+  .lang-active {
+    color: black;
+  }
+
+  .lang-inactive {
+    color: #cccccc;
+  }
+
+  .divider {
+    color: #cccccc;
+  }
 `;
 
 const UserContainer = styled.div`
@@ -237,4 +293,8 @@ const UserIcon = styled.img`
   @media all and (max-width: 479px) {
     margin-right: 0px;
   }
+`;
+
+const TranslateIcon = styled.img`
+  width: 2vh;
 `;

--- a/src/component/ui/class/AdminTopBar.jsx
+++ b/src/component/ui/class/AdminTopBar.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext, useRef } from "react";
-import { NavLink, useParams, useNavigate } from "react-router-dom";
+import { NavLink, useParams, useNavigate, useLocation } from "react-router-dom";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import Delete from "../../img/icon/bin.svg";
@@ -217,6 +217,8 @@ const AdminTopBar = ({ activeTab }) => {
   const { courseId } = useParams();
   const { user } = useContext(UsersContext);
   const navigate = useNavigate();
+  const location = useLocation();
+  const path = location.pathname;
   // 모달 관련 상태
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
@@ -227,6 +229,11 @@ const AdminTopBar = ({ activeTab }) => {
   const [currentCourse, setCurrentCourse] = useState(null);
   const dropdownRef = useRef(null);
   const iconRef = useRef(null);
+
+  const isSummaryTab =
+    path.includes("/admin/summary") || path.includes("/admin/students");
+
+  const isSettingTab = path.includes("/admin/setting");
 
   useEffect(() => {
     if (!user?.userId) return;
@@ -307,17 +314,18 @@ const AdminTopBar = ({ activeTab }) => {
             <>
               <TabLink
                 to={`/class/${courseId}/admin/summary`}
-                className={activeTab === "summary" ? "active" : ""}
+                className={isSummaryTab ? "active" : ""}
               >
                 요약
               </TabLink>
-
+              {/*
               <TabLink
                 to={`/class/${courseId}/admin/students`}
                 className={activeTab === "students" ? "active" : ""}
               >
                 과제 보기
               </TabLink>
+              */}
             </>
           )}
 
@@ -325,19 +333,19 @@ const AdminTopBar = ({ activeTab }) => {
             <>
               <TabLink
                 to={`/class/${courseId}/admin/summary`}
-                className={activeTab === "summary" ? "active" : ""}
+                className={isSummaryTab ? "active" : ""}
               >
                 요약
               </TabLink>
-              <TabLink
+              {/* <TabLink
                 to={`/class/${courseId}/admin/students`}
                 className={activeTab === "students" ? "active" : ""}
               >
                 과제 보기
-              </TabLink>
+              </TabLink> */}
               <TabLink
                 to={`/class/${courseId}/admin/setting`}
-                className={activeTab === "setting" ? "active" : ""}
+                className={isSettingTab ? "active" : ""}
               >
                 설정
               </TabLink>

--- a/src/component/ui/class/ClassTopbar.jsx
+++ b/src/component/ui/class/ClassTopbar.jsx
@@ -148,6 +148,10 @@ const TabLinkContainer = styled.div`
   justify-content: flex-end;
   white-space: nowrap;
 
+  &.disabled {
+    pointer-events: none;
+  }
+
   @media (max-width: 1024px) {
     gap: 1rem;
   }
@@ -228,6 +232,7 @@ const ClassTopbar = ({ onCourseChange, isCreator }) => {
   const tabRef = useRef(null);
   const dropdownRef = useRef(null);
   const iconRef = useRef(null);
+  const isEditPage = location.pathname.includes("edit");
 
   useEffect(() => {
     const fetchClasses = async () => {
@@ -342,7 +347,7 @@ const ClassTopbar = ({ onCourseChange, isCreator }) => {
       <RightContainer>
         <TabLinkContainer
           ref={tabRef}
-          className={isScrollable ? "scrolling" : ""}
+          className={`${isScrollable ? "scrolling" : ""} ${isEditPage ? "disabled" : ""}`}
         >
           <TabLink
             to={`/class/${courseId}/overview/info`}

--- a/src/component/ui/class/StudentProgressTable.jsx
+++ b/src/component/ui/class/StudentProgressTable.jsx
@@ -4,6 +4,7 @@ import Profile from "../../img/class/profile.svg";
 import Done from "../../img/class/check/progress_done.svg";
 import Undone from "../../img/class/check/progress_undone.svg";
 import LateSubmission from "../../img/class/check/late_submission.svg";
+import { useNavigate, useParams } from "react-router-dom";
 
 const ScrollableTableContainer = styled.div`
   width: 100%;
@@ -202,8 +203,9 @@ const StudentProgressTable = ({ assignments }) => {
     assignment.studentStatuses.forEach((student) => {
       if (!studentsMap.has(student.userId)) {
         studentsMap.set(student.userId, {
+          userId: student.userId,
           name: student.studentName,
-          profile: Profile, // 기본 프로필 이미지 사용
+          profile: Profile,
           submissions: [],
         });
       }
@@ -217,6 +219,8 @@ const StudentProgressTable = ({ assignments }) => {
   const isDragging = useRef(false); // 드래그 상태 추적
   const startX = useRef(0);
   const scrollLeft = useRef(0);
+  const navigate = useNavigate();
+  const { courseId } = useParams();
 
   const handleScroll = () => {
     const scrollWidth =
@@ -297,19 +301,19 @@ const StudentProgressTable = ({ assignments }) => {
             {students.map((student, index) => (
               <tr key={index}>
                 <td>
-                  <ProfileContainer>
+                  <ProfileContainer
+                    onClick={() =>
+                      navigate(
+                        `/class/${courseId}/admin/students/${student.userId}`,
+                      )
+                    }
+                    style={{ cursor: "pointer" }}
+                  >
                     <ProfileImage src={student.profile} alt="프로필" />
                     {student.name}
                   </ProfileContainer>
                 </td>
-                {/* {student.submissions.map((submitted, idx) => (
-                  <td key={idx}>
-                    <CheckMarkIcon
-                      src={submitted ? Done : Undone}
-                      alt={submitted ? "제출 완료" : "미제출"}
-                    />
-                  </td>
-                ))} */}
+
                 {student.submissions.map((status, idx) => {
                   let iconSrc;
                   if (status === "SUBMITTED") {

--- a/src/utils/collectVisibleTexts.js
+++ b/src/utils/collectVisibleTexts.js
@@ -1,0 +1,22 @@
+export function collectVisibleTexts() {
+  const walker = document.createTreeWalker(
+    document.body,
+    NodeFilter.SHOW_TEXT,
+    {
+      acceptNode: (node) => {
+        if (!node.parentElement) return NodeFilter.FILTER_REJECT;
+        if (node.parentElement.tagName === "SCRIPT") return NodeFilter.FILTER_REJECT;
+        if (node.parentElement.tagName === "STYLE") return NodeFilter.FILTER_REJECT;
+        if (!node.nodeValue.trim()) return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    }
+  );
+
+  const texts = [];
+  while (walker.nextNode()) {
+    texts.push(walker.currentNode.nodeValue.trim());
+  }
+
+  return texts;
+}


### PR DESCRIPTION
# ✅ Check-List  
- [ ] merge할 브랜치 위치 확인 (develop)
- [ ] 리뷰어 지정 (필요 시)  
- [ ] 리뷰는 최대한 빠르게 진행  
- [ ] P1 단계 리뷰는 빠르게 확인 후 반영  
- [ ] Approve된 PR은 assigner가 머지, 수정 요청 시 재반영 후 push  

---

## 📌 Related Issues  
- closed: #170 

---

## 📎 작업 내용  
- 학생별 보기 페이지 삭제 + 상단바에서 제거
- 요약 페이지에서 학생별 상세 보기 페이지로 이동할 수 있도록 수정
- 학생별 상세 보기 페이지에서 요약 페이지로 넘어갈 수 있도록 수정
- 학생별 상세 보기 페이지에 있을 시, 상단바 내 요약 탭 활성화

---

## 📷 스크린샷  
(관련 이미지 첨부)  

---

## 💬 리뷰어 참고 사항  
번역 기능 구현 커밋이 중복돼서 올라간 것 같은데,, 더 수정된 거는 없어 괜찮을 것 같아서 우선 pr 만들었습니다.